### PR TITLE
add:render-build.sh追加

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -1,0 +1,6 @@
+set -o errexit
+
+bundle install
+bundle exec rails assets:precompile
+bundle exec rails assets:clean
+bundle exec rails db:migrate


### PR DESCRIPTION
## 概要
Render は、各デプロイの前に、指定したビルドコマンドを実行してアプリをビルドします。Rails アプリは通常、ビルドの一部として複数のコマンドを実行するため、それらを組み合わせたスクリプトを作成しましょう。（[Render公式サイトから引用](https://render.com/docs/deploy-rails-8#create-a-build-script)）

Closes #9

## 内容
binディレクトリ配下にrender-build,shを作成。