### PR TITLE
add:top画面の月までの距離とうさぎの数の表示

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,7 @@ class User < ApplicationRecord
   end
 
   def remaining_distance # 残りの距離
-    [GOAL_DISTANCE - total_distance, 0].max # 配列にして、最大数を返すようにしている。（負の数値が表示されないようにするため。
+    [ GOAL_DISTANCE - total_distance, 0 ].max # 配列にして、最大数を返すようにしている。（負の数値が表示されないようにするため。
   end
 
   def rabbit_count

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,19 @@ class User < ApplicationRecord
   validates :password, presence: true
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  GOAL_DISTANCE = 384_400 # 月の距離（定数のため大文字定義）
+  RABBIT_INTERVAL = 10_000 # うさぎが仲間に加わる数字（月の距離 / 10,000）
+
+  def total_distance
+    records.sum(:total_distance) # userモデルに定義しているため、ユーザーを指定する必要はない。（current_user.records.total_distanceとする必要がない）
+  end
+
+  def remaining_distance # 残りの距離
+    [GOAL_DISTANCE - total_distance, 0].max # 配列にして、最大数を返すようにしている。（負の数値が表示されないようにするため。
+  end
+
+  def rabbit_count
+    (total_distance / RABBIT_INTERVAL).floor
+  end
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -2,10 +2,10 @@
   <div style="max-width: 600px; text-align: center; padding: 20px;">
     <% if user_signed_in? %>
       <h1>🚀 Let's Go to the Mooooon!!</h1>
-      <p>🌕 月まであと <strong>〇〇 km</strong>!!</p>
-      <p>🐰 現在 <strong>〇 匹</strong> の仲間がいます</p>
+      <p>🌕 月まであと <strong> <%= number_with_delimiter(current_user.remaining_distance.floor) %> km</strong>!!</p>
+      <p>🐰 現在 <strong> <%= current_user.rabbit_count %> 匹</strong> の仲間がいます</p>
       <div style="margin-top: 20px;">
-        <%= link_to '本日の記録を行う！', new_record_path %>
+        <%= link_to '本日の記録を行う！', new_record_path, class: "class: bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-md" %>
       </div>
       <div style="margin-top: 20px;">
         <%= button_to 'ログアウト', destroy_user_session_path, method: :delete %>


### PR DESCRIPTION
## 概要
トップ画面に表示する、残り距離、うさぎを仲間にした数の実装
Closes #43 

## 実装内容
Userモデルに上記を計算するためのメソッドを定義。
（モデルに定義した理由は、ゆくゆくはほかの画面等でも使用したいため。）

[![Image from Gyazo](https://i.gyazo.com/7d7ea1c553c47b22ec6bb5d0146f46d5.png)](https://gyazo.com/7d7ea1c553c47b22ec6bb5d0146f46d5)

## 以下MVP後の対応

- 距離が0（GOAL）した画面の設定。
- うさぎの数はとりあえず38匹で止める？
- 背景画面の切り替え