### PR TITLE
fix:ボタン文言変更

### DIFF
--- a/app/views/records/_record.html.erb
+++ b/app/views/records/_record.html.erb
@@ -30,7 +30,7 @@
   </div>
 
   <div class="text-center">
-    <%= f.submit "記録を変更", class: "bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-md" %>
+    <%= f.submit "保存", class: "bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-md" %>
     <%= link_to '一覧へ戻る', records_path, class: "bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-md"%>
   </div>
 <% end %>


### PR DESCRIPTION
## 概要

新規作成ページ、編集ページの「記録を変更」ボタンを「保存」へ変更。